### PR TITLE
 Set range of wall mounted thermostats

### DIFF
--- a/src/devices/HmIPWallMountedThermostat.ts
+++ b/src/devices/HmIPWallMountedThermostat.ts
@@ -73,7 +73,12 @@ export class HmIPWallMountedThermostat extends HmIPGenericDevice implements Upda
 
     this.service.getCharacteristic(this.platform.Characteristic.TargetTemperature)
       .on('get', this.handleTargetTemperatureGet.bind(this))
-      .on('set', this.handleTargetTemperatureSet.bind(this));
+      .on('set', this.handleTargetTemperatureSet.bind(this))
+      .setProps({
+        minValue: 5,
+        maxValue: 30,
+        minStep: 0.5,
+      });
 
     this.service.getCharacteristic(this.platform.Characteristic.TemperatureDisplayUnits)
       .on('get', this.handleTemperatureDisplayUnitsGet.bind(this))


### PR DESCRIPTION
Based on https://github.com/marcsowen/homebridge-homematicip/pull/215 for setting the range for HmIPHeatingThermostat this does the same for HmIPWallMountedThermostat.