### PR TITLE
Add `asClimateSensor` config option for thermostats

### DIFF
--- a/src/HmIPPlatform.ts
+++ b/src/HmIPPlatform.ts
@@ -259,7 +259,13 @@ export class HmIPPlatform implements DynamicPlatformPlugin {
       || device.type === 'TEMPERATURE_HUMIDITY_SENSOR'
       || device.type === 'TEMPERATURE_HUMIDITY_SENSOR_DISPLAY'
       || device.type === 'WALL_MOUNTED_THERMOSTAT_BASIC_HUMIDITY') {
-      homebridgeDevice = new HmIPWallMountedThermostat(this, hmIPAccessory.accessory);
+      const accessoryConfig = this.config['devices']?.[device.id];
+      const asClimateSensor = accessoryConfig?.['asClimateSensor'] === true;
+      if (asClimateSensor) {
+        homebridgeDevice = new HmIPClimateSensor(this, hmIPAccessory.accessory);
+      } else {
+        homebridgeDevice = new HmIPWallMountedThermostat(this, hmIPAccessory.accessory);
+      }
     } else if (device.type === 'TEMPERATURE_HUMIDITY_SENSOR_OUTDOOR') {
       homebridgeDevice = new HmIPClimateSensor(this, hmIPAccessory.accessory);
     } else if (device.type === 'HEATING_THERMOSTAT'

--- a/src/devices/HmIPClimateSensor.ts
+++ b/src/devices/HmIPClimateSensor.ts
@@ -62,7 +62,9 @@ export class HmIPClimateSensor extends HmIPGenericDevice implements Updateable {
     super.updateDevice(hmIPDevice, groups);
     for (const id in hmIPDevice.functionalChannels) {
       const channel = hmIPDevice.functionalChannels[id];
-      if (channel.functionalChannelType === 'CLIMATE_SENSOR_CHANNEL') {
+      if (channel.functionalChannelType === 'CLIMATE_SENSOR_CHANNEL' 
+          || channel.functionalChannelType === 'WALL_MOUNTED_THERMOSTAT_WITHOUT_DISPLAY_CHANNEL'
+          || channel.functionalChannelType === 'WALL_MOUNTED_THERMOSTAT_PRO_CHANNEL') {
         const climateSensorChannel = <ClimateSensorChannel>channel;
 
         if (climateSensorChannel.actualTemperature !== this.actualTemperature) {


### PR DESCRIPTION
Hi @marcsowen,

out of personal need I added a config option `asClimateSensor` to force a device to identify as `HmIPClimateSensor` that would otherwise identify as `HmIPWallMountedThermostat` (see #116 and #364).

It's implemented more as a proof of concept (it's tested to work with my personal devices). Before moving forward with this, I would like to ask your opinion on if you would merge such a feature? If so, do you have a strong opinion how you would like to see it implemented?

I don't like bringing dependencies on thermostats into the `HmIPClimateSensor` class, but there seems to be no other way. I could image a shared function like 
```ts
const isTemperatureAndHumidityType = (type: string) => type === 'TEMPERATURE_HUMIDITY_SENSOR' || etc. ...
``` 
used in `HmIPClimateSensor` and `HmIPPlatform.updateAccessory()`. What do you think?

Thanks for the great plugin! Cheers, Ole