### PR TITLE
Fixed illegal value warning

### DIFF
--- a/src/devices/HmIPSwitch.ts
+++ b/src/devices/HmIPSwitch.ts
@@ -77,7 +77,7 @@ export class HmIPSwitch extends HmIPGenericDevice implements Updateable {
         const switchChannel = <SwitchChannel>channel;
         this.platform.log.debug(`Switch update: ${JSON.stringify(channel)}`);
 
-        if (switchChannel.on !== this.on) {
+        if (switchChannel.on !== null && switchChannel.on !== this.on) {
           this.on = switchChannel.on;
           this.platform.log.info('Switch state of %s changed to %s', this.accessory.displayName, this.on ? 'ON' : 'OFF');
           this.service.updateCharacteristic(this.platform.Characteristic.On, this.on);

--- a/src/devices/HmIPSwitchMeasuring.ts
+++ b/src/devices/HmIPSwitchMeasuring.ts
@@ -90,7 +90,7 @@ export class HmIPSwitchMeasuring extends HmIPGenericDevice implements Updateable
         const switchMeasuringChannel = <SwitchMeasuringChannel>channel;
         this.platform.log.debug('Switch (measuring) update: %s', JSON.stringify(channel));
 
-        if (switchMeasuringChannel.on !== this.on) {
+        if (switchMeasuringChannel.on != null && switchMeasuringChannel.on !== this.on) {
           this.on = switchMeasuringChannel.on;
           this.platform.log.info('Switch state of %s changed to %s', this.accessory.displayName, this.on ? 'ON' : 'OFF');
           this.service.updateCharacteristic(this.platform.Characteristic.On, this.on);

--- a/src/devices/HmIPSwitchNotificationLight.ts
+++ b/src/devices/HmIPSwitchNotificationLight.ts
@@ -363,7 +363,7 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
         const switchChannel = <SwitchChannel>channel;
         this.platform.log.debug(`Switch update: ${JSON.stringify(channel)}`);
 
-        if (switchChannel.on !== this.on) {
+        if (switchChannel.on !== null && switchChannel.on !== this.on) {
           this.on = switchChannel.on;
           this.platform.log.info('Switch state of %s changed to %s', this.accessory.displayName, this.on ? 'ON' : 'OFF');
           this.service.updateCharacteristic(this.platform.Characteristic.On, this.on);


### PR DESCRIPTION
Fixed warning when switches are disconnected/not reachable
```
This plugin generated a warning from the characteristic 'On': characteristic was supplied illegal value: null! Home App will reject null for Apple defined characteristics. See https://homebridge.io/w/JtMGR for more info.
```
The issue might also occur for other disconnected devices, however I fixed it for the switches families only.