### PR TITLE
Improve WallMountedThermostat

### DIFF
--- a/src/HmIPState.ts
+++ b/src/HmIPState.ts
@@ -40,6 +40,7 @@ export interface HmIPHeatingGroup {
   humidity: number;
   minTemperature: number;
   maxTemperature: number;
+  controlMode: string;
 }
 
 export interface HmIPHome {

--- a/src/HmIPState.ts
+++ b/src/HmIPState.ts
@@ -38,6 +38,8 @@ export interface HmIPHeatingGroup {
   setPointTemperature: number;
   actualTemperature: number;
   humidity: number;
+  minTemperature: number;
+  maxTemperature: number;
 }
 
 export interface HmIPHome {

--- a/src/devices/HmIPHeatingThermostat.ts
+++ b/src/devices/HmIPHeatingThermostat.ts
@@ -61,10 +61,7 @@ export class HmIPHeatingThermostat extends HmIPGenericDevice implements Updateab
 
     this.service.getCharacteristic(this.platform.Characteristic.TargetHeatingCoolingState)
       .on('get', this.handleTargetHeatingCoolingStateGet.bind(this))
-      .on('set', this.handleTargetHeatingCoolingStateSet.bind(this))
-      .setProps({
-        validValues: [this.platform.Characteristic.TargetHeatingCoolingState.HEAT]
-      });
+      .on('set', this.handleTargetHeatingCoolingStateSet.bind(this));
 
     this.service.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
       .on('get', this.handleCurrentTemperatureGet.bind(this));
@@ -89,7 +86,7 @@ export class HmIPHeatingThermostat extends HmIPGenericDevice implements Updateab
   }
 
   handleTargetHeatingCoolingStateGet(callback: CharacteristicGetCallback) {
-    callback(null, this.platform.Characteristic.TargetHeatingCoolingState.HEAT);
+    callback(null, this.platform.Characteristic.TargetHeatingCoolingState.AUTO);
   }
 
   handleTargetHeatingCoolingStateSet(value: CharacteristicValue, callback: CharacteristicSetCallback) {

--- a/src/devices/HmIPHeatingThermostat.ts
+++ b/src/devices/HmIPHeatingThermostat.ts
@@ -61,7 +61,10 @@ export class HmIPHeatingThermostat extends HmIPGenericDevice implements Updateab
 
     this.service.getCharacteristic(this.platform.Characteristic.TargetHeatingCoolingState)
       .on('get', this.handleTargetHeatingCoolingStateGet.bind(this))
-      .on('set', this.handleTargetHeatingCoolingStateSet.bind(this));
+      .on('set', this.handleTargetHeatingCoolingStateSet.bind(this))
+      .setProps({
+        validValues: [this.platform.Characteristic.TargetHeatingCoolingState.HEAT]
+      });
 
     this.service.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
       .on('get', this.handleCurrentTemperatureGet.bind(this));
@@ -86,7 +89,7 @@ export class HmIPHeatingThermostat extends HmIPGenericDevice implements Updateab
   }
 
   handleTargetHeatingCoolingStateGet(callback: CharacteristicGetCallback) {
-    callback(null, this.platform.Characteristic.TargetHeatingCoolingState.AUTO);
+    callback(null, this.platform.Characteristic.TargetHeatingCoolingState.HEAT);
   }
 
   handleTargetHeatingCoolingStateSet(value: CharacteristicValue, callback: CharacteristicSetCallback) {

--- a/src/devices/HmIPWallMountedThermostat.ts
+++ b/src/devices/HmIPWallMountedThermostat.ts
@@ -23,7 +23,6 @@ interface WallMountedThermostatChannel {
 interface WallMountedThermostatInternalSwitchChannel {
   functionalChannelType: string;
   valvePosition: number;
-  frostProtectionTemperature: number;
 }
 
 /**
@@ -49,7 +48,6 @@ export class HmIPWallMountedThermostat extends HmIPGenericDevice implements Upda
   private valvePosition: number | null = null;
   private minTemperature = 5;
   private maxTemperature = 30;
-  private frostProtectionTemperature: number = this.minTemperature;
   private readonly historyService;
 
   constructor(
@@ -144,8 +142,7 @@ export class HmIPWallMountedThermostat extends HmIPGenericDevice implements Upda
       };
       await this.platform.connector.apiCall('group/heating/setControlMode', body);
       if (stateName === 'OFF') {
-        this.service.setCharacteristic(this.platform.Characteristic.TargetTemperature,
-          Math.max(this.frostProtectionTemperature, this.minTemperature));
+        this.service.setCharacteristic(this.platform.Characteristic.TargetTemperature, this.minTemperature);
       }
     }
     callback(null);
@@ -270,12 +267,6 @@ export class HmIPWallMountedThermostat extends HmIPGenericDevice implements Upda
           this.valvePosition = wthsChannel.valvePosition;
           this.platform.log.info('Valve position of %s changed to %s', this.accessory.displayName, this.valvePosition);
           this.service.updateCharacteristic(this.platform.Characteristic.CurrentHeatingCoolingState, this.getHeatingCoolingState());
-        }
-
-        if (wthsChannel.frostProtectionTemperature !== null && wthsChannel.frostProtectionTemperature !== this.frostProtectionTemperature) {
-          this.frostProtectionTemperature = wthsChannel.frostProtectionTemperature;
-          this.platform.log.info('Frost protection temperature of %s changed to %s', this.accessory.displayName,
-            this.frostProtectionTemperature);
         }
       }
     }

--- a/src/devices/HmIPWallMountedThermostat.ts
+++ b/src/devices/HmIPWallMountedThermostat.ts
@@ -92,10 +92,10 @@ export class HmIPWallMountedThermostat extends HmIPGenericDevice implements Upda
   }
 
   handleCurrentHeatingCoolingStateGet(callback: CharacteristicGetCallback) {
-    callback(null, this.getHeatingCoolongState());
+    callback(null, this.getHeatingCoolingState());
   }
 
-  private getHeatingCoolongState() {
+  private getHeatingCoolingState() {
     return this.cooling ?
       this.platform.Characteristic.CurrentHeatingCoolingState.COOL :
       this.setPointTemperature > this.actualTemperature ?
@@ -191,7 +191,7 @@ export class HmIPWallMountedThermostat extends HmIPGenericDevice implements Upda
             if (heatingGroup.cooling !== null && heatingGroup.cooling !== this.cooling) {
               this.cooling = heatingGroup.cooling;
               this.platform.log.info('Cooling mode of %s changed to %s', this.accessory.displayName, this.cooling);
-              this.service.updateCharacteristic(this.platform.Characteristic.CurrentHeatingCoolingState, this.getHeatingCoolongState());
+              this.service.updateCharacteristic(this.platform.Characteristic.CurrentHeatingCoolingState, this.getHeatingCoolingState());
             }
           }
         }

--- a/src/devices/HmIPWallMountedThermostat.ts
+++ b/src/devices/HmIPWallMountedThermostat.ts
@@ -66,7 +66,10 @@ export class HmIPWallMountedThermostat extends HmIPGenericDevice implements Upda
 
     this.service.getCharacteristic(this.platform.Characteristic.TargetHeatingCoolingState)
       .on('get', this.handleTargetHeatingCoolingStateGet.bind(this))
-      .on('set', this.handleTargetHeatingCoolingStateSet.bind(this));
+      .on('set', this.handleTargetHeatingCoolingStateSet.bind(this))
+      .setProps({
+        validValues: [this.platform.Characteristic.TargetHeatingCoolingState.HEAT]
+      });
 
     this.service.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
       .on('get', this.handleCurrentTemperatureGet.bind(this));
@@ -101,7 +104,7 @@ export class HmIPWallMountedThermostat extends HmIPGenericDevice implements Upda
   }
 
   handleTargetHeatingCoolingStateGet(callback: CharacteristicGetCallback) {
-    callback(null, this.platform.Characteristic.TargetHeatingCoolingState.AUTO);
+    callback(null, this.platform.Characteristic.TargetHeatingCoolingState.HEAT);
   }
 
   handleTargetHeatingCoolingStateSet(value: CharacteristicValue, callback: CharacteristicSetCallback) {


### PR DESCRIPTION
Hi,

first, I want to thank you very much for this great plugin!

~~As both thermostats just ignore changes to `TargetHeatingCoolingState`, I propose to limit its valid values to `HEAT` only. This change results in a nicer UX, as the state selector is no longer visible in the Home app.~~

Looking forward to your feedback.

**Update**

- Also support getting/setting `AUTO` mode on WallMountedThermostat
- Use valvePosition (if available) on WallMountedThermostat to determine current state (`OFF`/`HEAT`) instead of approximating it

Those changes should not touch the behaviour of the (ignored) `COOL` state. So adding support for it in the future should be easy if someone with the right equipment figures out how to determine if `COOL` is supported (to add it to the list of valid values) and how to set it.

**Update 2**

- Respect min/max temperature from heating group to avoid API errors when setting a temperature that is out of this range

**Update 3**

- Having only `AUTO` and `OFF` modes resulted in poor UI in Home app (a single unlabelled button appears and is not clear if blue is `AUTO` or `HEAT`). So I created an artificial `OFF` mode (there is not real off state) to get a labeled chooser between the 3 modes where `OFF` sets control mode to `MANUAL` (as `HEAT` does) and sets the temperature to the minimum temperature. This should be a practical solution.