### PR TITLE
Guard against unnecessary API calls in WallMountedThermostat

### DIFF
--- a/src/devices/HmIPWallMountedThermostat.ts
+++ b/src/devices/HmIPWallMountedThermostat.ts
@@ -148,7 +148,9 @@ export class HmIPWallMountedThermostat extends HmIPGenericDevice implements Upda
       this.platform.log.info('Ignoring setting target heating/cooling state for %s to %s', this.accessory.displayName,
         stateName);
     } else {
-      this.platform.log.info('Setting target heating/cooling state for %s to %s', this.accessory.displayName, stateName);
+      if (value !== this.service.getCharacteristic(this.platform.Characteristic.TargetHeatingCoolingState).value) {
+        this.platform.log.info('Setting target heating/cooling state for %s to %s', this.accessory.displayName, stateName);
+      }
       if (controlMode !== this.controlMode) {
         this.platform.log.info('Setting control mode for %s to %s', this.accessory.displayName, controlMode);
         const body = {


### PR DESCRIPTION
Hey,

during intensive testing with WallMountedThermostat I realised that sometimes unnecessary API calls may happen and might add up in some scenarios, e.g. large scenes. So I added some guards to avoid such API calls and subsequently blocking.