### PR TITLE
Add reservoir to limiter

### DIFF
--- a/src/HmIPPlatform.ts
+++ b/src/HmIPPlatform.ts
@@ -141,7 +141,7 @@ export class HmIPPlatform implements DynamicPlatformPlugin {
       return;
     }
 
-    const hmIPState = <HmIPState>await this.connector.apiCall('home/getCurrentState', this.connector.clientCharacteristics);
+    const hmIPState = <HmIPState>await this.connector.apiCall('home/getCurrentState', this.connector.clientCharacteristics, 1);
     if (!hmIPState || !hmIPState.devices) {
       this.log.info(`HomematicIP response is incomplete or could not be parsed: ${hmIPState}`);
       return;

--- a/src/HmIPSecuritySystem.ts
+++ b/src/HmIPSecuritySystem.ts
@@ -93,7 +93,7 @@ export class HmIPSecuritySystem {
         EXTERNAL: target?.external,
       },
     };
-    await this.platform.connector.apiCall('home/security/setZonesActivation', body);
+    await this.platform.connector.apiCall('home/security/setZonesActivation', body, 2);
     callback(null);
   }
 


### PR DESCRIPTION
Hi again 👋 

I am proposing to use the existing limiters reservoir feature to
- allow for small bursts, which ist very useful e.g. when using 'large' scenes (10/1s = 5x more in the first second)
- avoid getting blocked by decreasing the request limit per second (1/s = 0.5x the current number of RPS)

I added a high water mark to the limiter to drop calls that are older than approx. 2 minutes as processing very old request does not seem to be very useful in practice.

This PR also opens up the possibility to prioritise important requests depending on the device (e.g. unlocking the door).

The concrete numbers work for me right now, but should be discussed - maybe @marcsowen or someone else having more experience with the blocking behaviour of the API than me can give some feedback on that?