### PR TITLE
Code cleanup for HmIP-BSL: fixed various bugs, added support for firmware version 2.0.2

### DIFF
--- a/src/CustomCharacteristic.ts
+++ b/src/CustomCharacteristic.ts
@@ -8,6 +8,11 @@ export class CustomCharacteristic {
   constructor(api: API) {
     this.api = api;
 
+    this.createCharacteristics('OpticalSignal', 'a11c14a7-bb9b-4085-8597-68cf63964bf8', {
+      format: Formats.STRING,
+      perms: [Perms.NOTIFY, Perms.PAIRED_WRITE, Perms.PAIRED_READ],
+    });
+
     this.createCharacteristics('ElectricPower', 'E863F10D-079E-48FF-8F27-9C2605A29F52', {
       format: Formats.FLOAT,
       perms: [Perms.NOTIFY, Perms.PAIRED_READ],


### PR DESCRIPTION
The new firmware for HmIP-BSL switch with notification lights breaks the existing code, so here is a patch to get it working again. The new firmware implements a so called optical signal behaviour. For example the lights can blink automatically now. In addition, I also cleaned up the code and fixed some bugs.