### PR TITLE
Added light sensor service to HmIP motion sensors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,13 @@ See [Wiki](https://github.com/marcsowen/homebridge-homematicip/wiki) for details
 - HmIP-PS Pluggable switch
 - HmIP-PCBS Switch circuit board - 1 channel
 - HmIP-PCBS-BAT Printed circuit board switch battery
-- HmIP-PCBS2 Switch circuit board - 2x channels [1]
-- HmIP-MOD-OC8 Open collector module [1]
-- HmIP-WHS2 Switch actuator for heating systems – 2x channels [1]
-- HmIP-DRS8 Wired switch actuator – 8x channels [1]
-- HmIP-DRSI4 Switch actuator for DIN rail mount – 4x channels [1]
+- HmIP-PCBS2 Switch circuit board - 2x channels
+- HmIP-MOD-OC8 Open collector module
+- HmIP-WHS2 Switch actuator for heating systems – 2x channels
+- HmIPW-DRS8 Wired switch actuator – 8x channels
+- HmIPW-DRS4 Wired switch actuator – 4x channels
+- HmIP-BS2 Brand switch - 2x channels
+- HmIP-DRSI4 Switch actuator for DIN rail mount – 4x channels
 - HmIP-PSM Pluggable switch and meter
 - HmIP-BSM Brand switch and meter
 - HmIP-FSM, HmIP-FSM16 Full flush switch and meter

--- a/src/HmIPPlatform.ts
+++ b/src/HmIPPlatform.ts
@@ -290,12 +290,14 @@ export class HmIPPlatform implements DynamicPlatformPlugin {
       homebridgeDevice = new HmIPSmokeDetector(this, hmIPAccessory.accessory);
     } else if ( device.type === 'PLUGABLE_SWITCH'
       || device.type === 'FULL_FLUSH_INPUT_SWITCH'
+      || device.type === 'BRAND_SWITCH_2'
       || device.type === 'PRINTED_CIRCUIT_BOARD_SWITCH_BATTERY'
-      || device.type === 'PRINTED_CIRCUIT_BOARD_SWITCH_2' // Only first channel
-      || device.type === 'OPEN_COLLECTOR_8_MODULE' // Only first channel
-      || device.type === 'HEATING_SWITCH_2' // Only first channel
-      || device.type === 'WIRED_SWITCH_8' // Only first channel
-      || device.type === 'DIN_RAIL_SWITCH_4') { // Only first channel
+      || device.type === 'PRINTED_CIRCUIT_BOARD_SWITCH_2'
+      || device.type === 'OPEN_COLLECTOR_8_MODULE'
+      || device.type === 'HEATING_SWITCH_2'
+      || device.type === 'WIRED_SWITCH_8'
+      || device.type === 'WIRED_SWITCH_4'
+      || device.type === 'DIN_RAIL_SWITCH_4') {
       homebridgeDevice = new HmIPSwitch(this, hmIPAccessory.accessory);
     } else if ( device.type === 'PLUGABLE_SWITCH_MEASURING'
       || device.type === 'BRAND_SWITCH_MEASURING'

--- a/src/devices/HmIPMotionDetector.ts
+++ b/src/devices/HmIPMotionDetector.ts
@@ -15,11 +15,6 @@ interface MotionDetectionChannel {
 }
 
 /**
- * Correction factor to compute Lux from HmIP brightness sensor
- */
-const BRIGHTNESS_CORRECTION = 0.2;
-
-/**
  * HomematicIP motion detector
  *
  * HmIP-SMI (Motion Detector with Brightness Sensor - indoor)
@@ -109,13 +104,10 @@ export class HmIPMotionDetector extends HmIPGenericDevice implements Updateable 
           this.platform.log.debug('Motion detector state of %s changed to %s', this.accessory.displayName, this.motionDetected);
           this.motionSensorService.updateCharacteristic(this.platform.Characteristic.MotionDetected, this.motionDetected);
         }
-        if (motionDetectionChannel.illumination !== null) {
-            const level = motionDetectionChannel.illumination * BRIGHTNESS_CORRECTION;
-            if (level !== this.lightLevel) {
-              this.lightLevel = level;
-              this.platform.log.debug('Illumination detector state of %s changed to %s', this.accessory.displayName, level);
-              this.motionSensorService.updateCharacteristic(this.platform.Characteristic.CurrentAmbientLightLevel, level);
-            }
+        if (motionDetectionChannel.illumination !== null && motionDetectionChannel.illumination !== this.lightLevel) {
+          this.lightLevel = motionDetectionChannel.illumination;
+          this.platform.log.debug('Illumination detector state of %s changed to %s', this.accessory.displayName, this.lightLevel);
+          this.motionSensorService.updateCharacteristic(this.platform.Characteristic.CurrentAmbientLightLevel, this.lightLevel);
         }
       }
 

--- a/src/devices/HmIPMotionDetector.ts
+++ b/src/devices/HmIPMotionDetector.ts
@@ -28,7 +28,7 @@ export class HmIPMotionDetector extends HmIPGenericDevice implements Updateable 
 
   private motionDetected = false;
   private sabotage = false;
-  private lightLevel = 0;
+  private lightLevel = 1;
 
   private addLightSensor : boolean = false;
 
@@ -88,7 +88,7 @@ export class HmIPMotionDetector extends HmIPGenericDevice implements Updateable 
   }
 
   handleAmbientLightLevelGet(callback: CharacteristicGetCallback) {
-    callback(null, this.lightLevel);
+    callback(null, this.lightLevel < 1 ? 1 : this.lightLevel);
   }
 
   public updateDevice(hmIPDevice: HmIPDevice, groups: { [key: string]: HmIPGroup }) {
@@ -101,13 +101,17 @@ export class HmIPMotionDetector extends HmIPGenericDevice implements Updateable 
 
         if (motionDetectionChannel.motionDetected !== null && motionDetectionChannel.motionDetected !== this.motionDetected) {
           this.motionDetected = motionDetectionChannel.motionDetected;
-          this.platform.log.debug('Motion detector state of %s changed to %s', this.accessory.displayName, this.motionDetected);
-          this.motionSensorService.updateCharacteristic(this.platform.Characteristic.MotionDetected, this.motionDetected);
+          this.platform.log.debug('Motion detector state of %s changed to %s', this.accessory.displayName,
+				  this.motionDetected);
+          this.motionSensorService.updateCharacteristic(this.platform.Characteristic.MotionDetected,
+							this.motionDetected);
         }
         if (motionDetectionChannel.illumination !== null && motionDetectionChannel.illumination !== this.lightLevel) {
           this.lightLevel = motionDetectionChannel.illumination;
-          this.platform.log.debug('Illumination detector state of %s changed to %s', this.accessory.displayName, this.lightLevel);
-          this.motionSensorService.updateCharacteristic(this.platform.Characteristic.CurrentAmbientLightLevel, this.lightLevel);
+          this.platform.log.debug('Illumination detector state of %s changed to %s', this.accessory.displayName,
+				  this.lightLevel);
+          this.motionSensorService.updateCharacteristic(this.platform.Characteristic.CurrentAmbientLightLevel,
+							this.lightLevel < 1 ? 1 : this.lightLevel);
         }
       }
 

--- a/src/devices/HmIPSwitch.ts
+++ b/src/devices/HmIPSwitch.ts
@@ -11,11 +11,15 @@ import {HmIPDevice, HmIPGroup, Updateable} from '../HmIPState.js';
 import {HmIPGenericDevice} from './HmIPGenericDevice.js';
 
 interface SwitchChannel {
-    functionalChannelType: string;
-    on: boolean;
-    profileMode: string;
-    userDesiredProfileMode: string;
+  functionalChannelType: string;
+  label : string;
+  on: boolean;
+  profileMode: string;
+  userDesiredProfileMode: string;
+  index : number;
+  hapService: Service;
 }
+
 
 /**
  * HomematicIP switch
@@ -24,19 +28,19 @@ interface SwitchChannel {
  *
  * HMIP-PS (Pluggable Switch)
  * HMIP-FSI16 (Full Flush Input Switch)
+ * HMIP-BS2 (Brand Switch - 2x channels)
  * HMIP-PCBS (Switch Circuit Board - 1 channel)
  * HMIP-PCBS-BAT (Printed Circuit Board Switch Battery)
  * HMIP-PCBS2 (Switch Circuit Board - 2x channels)
  * HMIP-MOD-OC8 ( Open Collector Module )
  * HMIP-WHS2 (Switch Actuator for heating systems – 2x channels)
  * HMIPW-DRS8 (Homematic IP Wired Switch Actuator – 8x channels)
- * HMIP-DRSI4 (Homematic IP Switch Actuator for DIN rail mount – 4x channels) """
+ * HMIPW-DRS4 (Homematic IP Wired Switch Actuator – 4x channels)
+ * HMIP-DRSI4 (Homematic IP Switch Actuator for DIN rail mount – 4x channels)
  *
  */
 export class HmIPSwitch extends HmIPGenericDevice implements Updateable {
-  private service: Service;
-
-  private on = false;
+  private channels = new Map<number, SwitchChannel>();
 
   constructor(
     platform: HmIPPlatform,
@@ -45,24 +49,56 @@ export class HmIPSwitch extends HmIPGenericDevice implements Updateable {
     super(platform, accessory);
 
     this.platform.log.debug(`Created switch ${accessory.context.device.label}`);
-    this.service = this.accessory.getService(this.platform.Service.Switch) || this.accessory.addService(this.platform.Service.Switch);
-    this.service.setCharacteristic(this.platform.Characteristic.Name, accessory.context.device.label);
 
-    this.updateDevice(accessory.context.device, platform.groups);
+    for (const id in accessory.context.device.functionalChannels) {
+      const channel = accessory.context.device.functionalChannels[id];
+      if (channel.functionalChannelType === 'SWITCH_CHANNEL' ||
+          channel.functionalChannelType === 'MULTI_MODE_INPUT_SWITCH_CHANNEL') {
+        const switchChannel = <SwitchChannel>channel;
 
-    this.service.getCharacteristic(this.platform.Characteristic.On)
-      .on('get', this.handleOnGet.bind(this))
-      .on('set', this.handleOnSet.bind(this));
+        if (!this.channels.has(switchChannel.index)) {
+          switchChannel.hapService = <Service>this.accessory.getServiceById(this.platform.Service.Switch,
+									    switchChannel.index.toString());
+          if (!switchChannel.hapService) {
+            const label = (switchChannel.label == null || switchChannel.label == '')
+				? accessory.context.device.label
+				: switchChannel.label;
+            const service = new this.platform.Service.Switch(label, switchChannel.index.toString());
+            switchChannel.hapService = this.accessory.addService(service);
+          }
+          switchChannel.hapService.getCharacteristic(this.platform.Characteristic.On)
+            .on('get', (callback) => {
+              this.handleOnGet(switchChannel, callback)
+            })
+            .on('set', (value, callback) => {
+              this.handleOnSet(switchChannel, value, callback)
+            });
+          this.channels.set(switchChannel.index, switchChannel);
+          this.platform.log.info('Added switch channel %d to %s', switchChannel.index, this.accessory.displayName);
+        }
+      }
+    }
+
+    if (this.channels.size == 0) {
+      this.platform.log.warn('No functional channels found for device %s', this.accessory.displayName);
+    } else {
+      this.updateDevice(accessory.context.device, platform.groups);
+    }
   }
 
-  handleOnGet(callback: CharacteristicGetCallback) {
-    callback(null, this.on);
+
+  /* Determine current switch state */
+  handleOnGet(switchChannel: SwitchChannel, callback: CharacteristicGetCallback) {
+    callback(null, switchChannel.on);
   }
 
-  async handleOnSet(value: CharacteristicValue, callback: CharacteristicSetCallback) {
-    this.platform.log.info('Setting switch %s to %s', this.accessory.displayName, value ? 'ON' : 'OFF');
+
+  /* Set new switch state */
+  async handleOnSet(switchChannel: SwitchChannel, value: CharacteristicValue, callback: CharacteristicSetCallback) {
+    this.platform.log.info('Setting switch %s channel %d to %s', this.accessory.displayName,
+			   switchChannel.index, value ? 'ON' : 'OFF');
     const body = {
-      channelIndex: 1,
+      channelIndex: switchChannel.index,
       deviceId: this.accessory.context.device.id,
       on: value,
     };
@@ -70,18 +106,34 @@ export class HmIPSwitch extends HmIPGenericDevice implements Updateable {
     callback(null);
   }
 
+
+  /* Update device state */
   public updateDevice(hmIPDevice: HmIPDevice, groups: { [key: string]: HmIPGroup }) {
     super.updateDevice(hmIPDevice, groups);
     for (const id in hmIPDevice.functionalChannels) {
       const channel = hmIPDevice.functionalChannels[id];
       if (channel.functionalChannelType === 'SWITCH_CHANNEL') {
         const switchChannel = <SwitchChannel>channel;
-        this.platform.log.debug(`Switch update: ${JSON.stringify(channel)}`);
+        const currentChannel = this.channels.get(switchChannel.index);
+        //this.platform.log.debug(`Switch update: ${JSON.stringify(channel)}`);
 
-        if (switchChannel.on !== null && switchChannel.on !== this.on) {
-          this.on = switchChannel.on;
-          this.platform.log.info('Switch state of %s changed to %s', this.accessory.displayName, this.on ? 'ON' : 'OFF');
-          this.service.updateCharacteristic(this.platform.Characteristic.On, this.on);
+	if (currentChannel) {
+
+          if (switchChannel.label != '' && switchChannel.label != currentChannel.label) {
+            currentChannel.label = switchChannel.label;
+	    currentChannel.hapService.displayName = switchChannel.label;
+            currentChannel.hapService.updateCharacteristic(this.platform.Characteristic.Name, switchChannel.label);
+            this.platform.log.debug('Switch label of %s channel %d changed to %s', this.accessory.displayName,
+				   currentChannel.index, switchChannel.label);
+          }
+
+          if (switchChannel.on !== currentChannel.on) {
+            currentChannel.on = switchChannel.on;
+            currentChannel.hapService.updateCharacteristic(this.platform.Characteristic.On, switchChannel.on);
+            this.platform.log.debug('Switch state of %s channel %d changed to %s', this.accessory.displayName,
+				   currentChannel.index, switchChannel.on ? 'ON' : 'OFF');
+          }
+
         }
       }
     }

--- a/src/devices/HmIPSwitchMeasuring.ts
+++ b/src/devices/HmIPSwitchMeasuring.ts
@@ -110,6 +110,7 @@ export class HmIPSwitchMeasuring extends HmIPGenericDevice implements Updateable
             this.accessory.displayName, this.energyCounter.toFixed(3));
           this.service.updateCharacteristic(this.platform.customCharacteristic.characteristic.ElectricalEnergy, this.energyCounter);
         }
+        break;
       }
     }
   }

--- a/src/devices/HmIPSwitchNotificationLight.ts
+++ b/src/devices/HmIPSwitchNotificationLight.ts
@@ -120,7 +120,7 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
       this.button1Led = <Service>this.accessory.getServiceById(this.platform.Service.Lightbulb, 'Button1');
       if (channel.functionalChannelType === 'NOTIFICATION_LIGHT_CHANNEL') {
         if (!this.button1Led) {
-          this.button1Led = new this.platform.Service.Lightbulb(accessory.context.device.label, 'Button1');
+          this.button1Led = new this.platform.Service.Lightbulb(channel.label, 'Button1');
           if (this.button1Led) {
             this.button1Led = this.accessory.addService(this.button1Led);
           } else {
@@ -140,7 +140,7 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
       this.button2Led = <Service>this.accessory.getServiceById(this.platform.Service.Lightbulb, 'Button2');
       if (channel.functionalChannelType === 'NOTIFICATION_LIGHT_CHANNEL') {
         if (!this.button2Led) {
-          this.button2Led = new this.platform.Service.Lightbulb(accessory.context.device.label, 'Button2');
+          this.button2Led = new this.platform.Service.Lightbulb(channel.label, 'Button2');
           if (this.button2Led) {
             this.button2Led = this.accessory.addService(this.button2Led);
           } else {
@@ -230,7 +230,7 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
   }
 
   async handleOnSet(value: CharacteristicValue, callback: CharacteristicSetCallback) {
-    this.platform.log.info('Setting switch %s to %s', this.accessory.displayName, value ? 'ON' : 'OFF');
+    this.platform.log.debug('Setting switch %s to %s', this.accessory.displayName, value ? 'ON' : 'OFF');
     const body = {
       channelIndex: 1,
       deviceId: this.accessory.context.device.id,
@@ -499,34 +499,32 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
    * Update state of lights
    */
   updateLightState(light : NotificationLight, channel : NotificationLightChannel){
-    if (light.index === channel.index && light.service !== undefined) {
+    if (light.service !== undefined) {
       
-      if (light.label !== channel.label) {
+      if (channel.label !== '' && light.label !== channel.label) {
         light.label = channel.label;
-        this.platform.log.debug('Update light label of %s to %s', this.accessory.displayName, light.label);
         light.service.displayName = light.label;
         light.service.updateCharacteristic(this.platform.Characteristic.Name, light.label);
+        this.platform.log.debug('Update light label of %s to %s', this.accessory.displayName, light.label);
       }
 
       if (light.on !== channel.on){
         light.on = channel.on;
-        this.platform.log.debug('Update light state of %s:%s to %s', this.accessory.displayName,
-          light.label, light.on ? 'ON' : 'OFF');
         light.service.updateCharacteristic(this.platform.Characteristic.On, light.on);
+        this.platform.log.debug('Update light state of %s:%s to %s', this.accessory.displayName,
+				light.label, light.on ? 'ON' : 'OFF');
       }
 
       const brightness = channel.dimLevel * 100.0;
       if (brightness !== null && brightness !== light.brightness) {
         light.brightness = brightness;
-        this.platform.log.debug('Update light brightness of %s:%s to %s %%', this.accessory.displayName,
-          light.label, light.brightness.toFixed(0));
         light.service.updateCharacteristic(this.platform.Characteristic.Brightness, light.brightness);
+        this.platform.log.debug('Update light brightness of %s:%s to %s %%', this.accessory.displayName,
+				light.label, light.brightness.toFixed(0));
       }
 
       if (light.simpleColor !== channel.simpleRGBColorState) {
         const newColor = channel.simpleRGBColorState;
-        this.platform.log.debug('Update light color of %s:%s to %s', this.accessory.displayName,
-          light.label, newColor);
         const hsl = HmIPColorPaletteHSL.get(newColor);            
         if (hsl !== undefined) {
           light.simpleColor = newColor;              
@@ -537,9 +535,11 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
             light.service.updateCharacteristic(this.platform.Characteristic.Hue, light.hue);
             light.service.updateCharacteristic(this.platform.Characteristic.Saturation, light.saturation);              
           }
+          this.platform.log.debug('Update light color of %s:%s to %s', this.accessory.displayName,
+				  light.label, newColor);
         } else {
           this.platform.log.error('Light color not supported for %s:%s', this.accessory.displayName,
-            light.label);
+				  light.label);
         }
       }
 
@@ -547,14 +547,20 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
         const opticalSignal = channel.opticalSignalBehaviour;
         if (opticalSignal !== null && opticalSignal !== light.opticalSignal) {
           light.opticalSignal = opticalSignal;
+          light.service.updateCharacteristic(this.platform.customCharacteristic.characteristic.OpticalSignal,
+					     light.opticalSignal);
           this.platform.log.debug('Update optical signal of %s:%s to %s', this.accessory.displayName,
-            light.label, light.opticalSignal);
-          light.service.updateCharacteristic(this.platform.customCharacteristic.characteristic.OpticalSignal, light.opticalSignal);
+				  light.label, light.opticalSignal);
         }
       }
     }
   }
   
+
+  /*
+   * Update device state - note that there is only one functional channel with
+   * type SWITCH_CHANNEL on this device!
+   */
   public updateDevice(hmIPDevice: HmIPDevice, groups: { [key: string]: HmIPGroup }) {
     super.updateDevice(hmIPDevice, groups);
     for (const id in hmIPDevice.functionalChannels) {
@@ -563,20 +569,23 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
 
       if (channel.functionalChannelType === 'SWITCH_CHANNEL') {
         const switchChannel = <SwitchChannel>channel;
-        this.platform.log.debug(`Switch update: ${JSON.stringify(channel)}`);
+        //this.platform.log.debug(`Switch update: ${JSON.stringify(channel)}`);
 
         if (switchChannel.on !== null && switchChannel.on !== this.on) {
           this.on = switchChannel.on;
-          this.platform.log.info('Switch state of %s changed to %s', this.accessory.displayName,
-            this.on ? 'ON' : 'OFF');
           this.service.updateCharacteristic(this.platform.Characteristic.On, this.on);
+          this.platform.log.info('Switch state of %s changed to %s', this.accessory.displayName,
+				 this.on ? 'ON' : 'OFF');
         }
       }
 
       if (channel.functionalChannelType === 'NOTIFICATION_LIGHT_CHANNEL' && !this.simpleSwitch) {
         const notificationLightChannel = <NotificationLightChannel>channel;
-        this.updateLightState(this.topLight, notificationLightChannel);
-        this.updateLightState(this.bottomLight, notificationLightChannel);
+	if (notificationLightChannel.index == this.topLight.index) {
+          this.updateLightState(this.topLight, notificationLightChannel);
+        } else if (notificationLightChannel.index == this.bottomLight.index) {
+          this.updateLightState(this.bottomLight, notificationLightChannel);
+        }
       }
     }
   }


### PR DESCRIPTION
Added light sensor support to HmIP motion sensors. In order to remain compatible with existing implementations, it is necessary to enable this feature by explicitely setting "lightSensor: true" in a device specification in the Homebridge config file.