### PR TITLE
Added optional window state characteristic to security system

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ See [Wiki](https://github.com/marcsowen/homebridge-homematicip/wiki) for details
 - HmIP-FDT Dimming actuator flush-mount
 - HmIPW-DRD3 Wired dimming actuator – 3x channels [1]
 - HmIP-DRDI3 DIN rail dimming actuator (multichannel)
+- HmIP-RGBW LED dimming actuator (multichannel, only dimming, no hue/saturation control)
 - HmIP-DLD Door lock drive [2]
 - HmIP-DLS Door lock sensor
 - HmIP-BSL Notification light switch

--- a/src/HmIPPlatform.ts
+++ b/src/HmIPPlatform.ts
@@ -343,7 +343,8 @@ export class HmIPPlatform implements DynamicPlatformPlugin {
       || device.type === 'PLUGGABLE_DIMMER'
       || device.type === 'WIRED_DIMMER_3') { // Only first channel
       homebridgeDevice = new HmIPDimmer(this, hmIPAccessory.accessory);
-    } else if (device.type === 'DIN_RAIL_DIMMER_3') { // all channels
+    } else if (device.type === 'DIN_RAIL_DIMMER_3'
+      || device.type === 'RGBW_DIMMER') { // all channels
       homebridgeDevice = new HmIPDimmerMultiChannel(this, hmIPAccessory.accessory);  
     } else if (device.type === 'DOOR_LOCK_DRIVE') {
       homebridgeDevice = new HmIPDoorLockDrive(this, hmIPAccessory.accessory);

--- a/src/HmIPPlatform.ts
+++ b/src/HmIPPlatform.ts
@@ -355,7 +355,8 @@ export class HmIPPlatform implements DynamicPlatformPlugin {
     } else if (device.type === 'WEATHER_SENSOR_PRO') {
       homebridgeDevice = new HmIPWeatherSensorPro(this, hmIPAccessory.accessory);
     } else {
-      if (device.type !== 'HOME_CONTROL_ACCESS_POINT') {
+      if (device.type !== 'HOME_CONTROL_ACCESS_POINT' &&
+          device.type !== 'EXTERNAL') {
         this.log.warn(`Device not implemented: ${device.modelType} - ${device.label} via type ${device.type}`);
       }
       return;

--- a/src/HmIPSecuritySystem.ts
+++ b/src/HmIPSecuritySystem.ts
@@ -160,18 +160,18 @@ export class HmIPSecuritySystem {
             this.platform.log.info('Security system activation status for internal zone changed to %s', this.internalZoneActive);
             stateChanged = true;
           }
-        } else if (securityGroup.label === 'EXTERNAL') {
-          if (securityGroup.active !== this.externalZoneActive) {
-            this.externalZoneActive = securityGroup.active;
-            this.platform.log.info('Security system activation status for external zone changed to %s', this.externalZoneActive);
-            stateChanged = true;
-          }
           if (securityGroup.windowState !== null && securityGroup.windowState !== this.windowState) {
             this.windowState = securityGroup.windowState;
             this.service.updateCharacteristic(this.platform.Characteristic.ContactSensorState,
               this.windowState === WindowState.CLOSED
                 ? this.platform.Characteristic.ContactSensorState.CONTACT_DETECTED
                 : this.platform.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED);
+          }
+        } else if (securityGroup.label === 'EXTERNAL') {
+          if (securityGroup.active !== this.externalZoneActive) {
+            this.externalZoneActive = securityGroup.active;
+            this.platform.log.info('Security system activation status for external zone changed to %s', this.externalZoneActive);
+            stateChanged = true;
           }
         }
       }

--- a/src/HmIPSecuritySystem.ts
+++ b/src/HmIPSecuritySystem.ts
@@ -157,6 +157,8 @@ export class HmIPSecuritySystem {
       if (group.type === 'SECURITY_ZONE') {
         const securityGroup = <SecurityZoneGroup>group;
 
+        this.platform.log.info('Security system state changed for zone %s', securityGroup.label);
+
         if (securityGroup.label === 'INTERNAL') {
 
           if (securityGroup.active !== this.internalZoneActive) {
@@ -166,6 +168,7 @@ export class HmIPSecuritySystem {
           }
           if (securityGroup.windowState !== null && securityGroup.windowState !== this.internalWindowState) {
             this.internalWindowState = securityGroup.windowState;
+            this.platform.log.info('Security system window state for internal zone changed to %s', this.internalWindowState);
 	    windowChanged = true;
           }
 
@@ -178,6 +181,7 @@ export class HmIPSecuritySystem {
           }
           if (securityGroup.windowState !== null && securityGroup.windowState !== this.externalWindowState) {
             this.externalWindowState = securityGroup.windowState;
+            this.platform.log.info('Security system window state for external zone changed to %s', this.externalWindowState);
 	    windowChanged = true;
           }
         }
@@ -191,7 +195,6 @@ export class HmIPSecuritySystem {
 
     if (windowChanged) {
       this.service.updateCharacteristic(this.platform.Characteristic.ContactSensorState,
-		this.internalWindowState === WindowState.CLOSED &&
 		this.externalWindowState === WindowState.CLOSED
 			? this.platform.Characteristic.ContactSensorState.CONTACT_DETECTED
 			: this.platform.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED);

--- a/src/HmIPSecuritySystem.ts
+++ b/src/HmIPSecuritySystem.ts
@@ -110,8 +110,7 @@ export class HmIPSecuritySystem {
   }
 
   handleContactSensorStateGet(callback: CharacteristicGetCallback) {
-    callback(null, this.internalWindowState === WindowState.CLOSED &&
-                   this.externalWindowState === WindowState.CLOSED
+    callback(null, this.externalWindowState === WindowState.CLOSED
 			? this.platform.Characteristic.ContactSensorState.CONTACT_DETECTED
 			: this.platform.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED);
   }

--- a/src/devices/HmIPButton.ts
+++ b/src/devices/HmIPButton.ts
@@ -49,7 +49,7 @@ export class HmIPButton extends HmIPGenericDevice implements EventUpdateable {
         if (!this.channels.has(buttonChannel.index)) {
           const label = (buttonChannel.label == null || buttonChannel.label == '')
 				? `Button ${buttonChannel.index}`
-				: buttonChannel.label;
+				: `${buttonChannel.label} ${buttonChannel.index}`;
           buttonChannel.hapService = <Service>this.accessory.getServiceById(
 		  this.platform.Service.StatelessProgrammableSwitch, buttonChannel.index.toString());
           if (!buttonChannel.hapService) {

--- a/src/devices/HmIPButton.ts
+++ b/src/devices/HmIPButton.ts
@@ -41,7 +41,7 @@ export class HmIPButton extends HmIPGenericDevice implements EventUpdateable {
 
     this.platform.log.debug(`Created button ${accessory.context.device.label}`);
 
-    const needLabelIndex = (accessory.context.device.functionalChannels.size > 2);
+    const needLabelIndex = (accessory.context.device.functionalChannels.length > 2);
     for (const id in accessory.context.device.functionalChannels) {
       const channel = accessory.context.device.functionalChannels[id];
       if (channel.functionalChannelType === 'SINGLE_KEY_CHANNEL') {

--- a/src/devices/HmIPButton.ts
+++ b/src/devices/HmIPButton.ts
@@ -41,6 +41,7 @@ export class HmIPButton extends HmIPGenericDevice implements EventUpdateable {
 
     this.platform.log.debug(`Created button ${accessory.context.device.label}`);
 
+    const needLabelIndex = (accessory.context.device.functionalChannels.size > 2);
     for (const id in accessory.context.device.functionalChannels) {
       const channel = accessory.context.device.functionalChannels[id];
       if (channel.functionalChannelType === 'SINGLE_KEY_CHANNEL') {
@@ -48,19 +49,21 @@ export class HmIPButton extends HmIPGenericDevice implements EventUpdateable {
 
         if (!this.channels.has(buttonChannel.index)) {
           const label = (buttonChannel.label == null || buttonChannel.label == '')
-				? `Button ${buttonChannel.index}`
-				: `${buttonChannel.label} ${buttonChannel.index}`;
+				? `${accessory.context.device.label} Button ${buttonChannel.index}`
+				: buttonChannel.label;
           buttonChannel.hapService = <Service>this.accessory.getServiceById(
 		  this.platform.Service.StatelessProgrammableSwitch, buttonChannel.index.toString());
           if (!buttonChannel.hapService) {
             const service = new this.platform.Service.StatelessProgrammableSwitch(label,
 				buttonChannel.index.toString());
+            service.addCharacteristic(this.platform.Characteristic.ConfiguredName);
+	    if (needLabelIndex) {
+              service.updateCharacteristic(this.platform.Characteristic.ServiceLabelIndex,
+                                           buttonChannel.index);
+            }
             buttonChannel.hapService = this.accessory.addService(service);
           }
-          buttonChannel.hapService.updateCharacteristic(this.platform.Characteristic.ServiceLabelIndex,
-				buttonChannel.index);
-          buttonChannel.hapService.updateCharacteristic(this.platform.Characteristic.Name,
-				`${accessory.context.device.label} ${label}`);
+          buttonChannel.hapService.updateCharacteristic(this.platform.Characteristic.ConfiguredName, label);
           this.channels.set(buttonChannel.index, buttonChannel);
           this.platform.log.debug('Added button channel %d to %s', buttonChannel.index, this.accessory.displayName);
         }
@@ -90,8 +93,8 @@ export class HmIPButton extends HmIPGenericDevice implements EventUpdateable {
           if (buttonChannel.label !== null && buttonChannel.label != '' &&
               buttonChannel.label != currentChannel.label) {
             currentChannel.label = buttonChannel.label;
-	    currentChannel.hapService.displayName = buttonChannel.label;
-            currentChannel.hapService.updateCharacteristic(this.platform.Characteristic.Name, currentChannel.label);
+            currentChannel.hapService.updateCharacteristic(this.platform.Characteristic.ConfiguredName,
+								currentChannel.label);
             this.platform.log.debug('Button label of %s channel %d changed to %s', this.accessory.displayName,
 				   currentChannel.index, currentChannel.label);
           }

--- a/src/devices/HmIPDimmerMultiChannel.ts
+++ b/src/devices/HmIPDimmerMultiChannel.ts
@@ -25,6 +25,7 @@ interface MultiModeInputDimmerChannel {
  * HomematicIP multi channel dimmer
  *
  * HmIP-DRDI3 (Homematic IP Dimming Actuator – 3x channels)
+ * HmIP-RGBW  (Homematic IP LED Dimming Actuator - 2-4x channel depending on configuration)
  *
  */
 export class HmIPDimmerMultiChannel extends HmIPGenericDevice implements Updateable {
@@ -81,9 +82,12 @@ export class HmIPDimmerMultiChannel extends HmIPGenericDevice implements Updatea
        const channel = hmIPDevice.functionalChannels[id];
        //this.platform.log.info(`Dimmer update: ${JSON.stringify(channel)}`);
 
-       if (channel.functionalChannelType === 'MULTI_MODE_INPUT_DIMMER_CHANNEL') { 
+       if (channel.functionalChannelType === 'MULTI_MODE_INPUT_DIMMER_CHANNEL' ||
+           channel.functionalChannelType === 'UNIVERSAL_LIGHT_CHANNEL') {
         this.platform.log.debug(`Dimmer update: ${JSON.stringify(channel)}`);
         const dimmerChannel = <MultiModeInputDimmerChannel>channel;
+
+        if (!dimmerChannel.label) continue;
 
         if (!this.channels.has(dimmerChannel.index)){
 

--- a/src/devices/HmIPDimmerMultiChannel.ts
+++ b/src/devices/HmIPDimmerMultiChannel.ts
@@ -36,7 +36,7 @@ export class HmIPDimmerMultiChannel extends HmIPGenericDevice implements Updatea
     platform: HmIPPlatform,
     accessory: PlatformAccessory,
   ) {
-   super(platform, accessory);
+    super(platform, accessory);
     this.platform.log.debug(`Created dimmer ${accessory.context.device.label}`);
 
     /* necessary services will be created during updateDevice() */
@@ -78,6 +78,7 @@ export class HmIPDimmerMultiChannel extends HmIPGenericDevice implements Updatea
 
   public updateDevice(hmIPDevice: HmIPDevice, groups: { [key: string]: HmIPGroup }) {
     super.updateDevice(hmIPDevice, groups);
+    const needLabelIndex = (this.accessory.context.device.functionalChannels.size > 2);
     for (const id in hmIPDevice.functionalChannels) {
        const channel = hmIPDevice.functionalChannels[id];
        //this.platform.log.info(`Dimmer update: ${JSON.stringify(channel)}`);
@@ -95,10 +96,15 @@ export class HmIPDimmerMultiChannel extends HmIPGenericDevice implements Updatea
           if (!dimmerChannel.hapService){
             const service = new this.platform.Service.Lightbulb(dimmerChannel.label, dimmerChannel.index.toString());
             service.addCharacteristic(this.platform.Characteristic.ConfiguredName);
+	    if (needLabelIndex) {
+              service.updateCharacteristic(this.platform.Characteristic.ServiceLabelIndex,
+						dimmerChannel.index);
+            }
             dimmerChannel.hapService = this.accessory.addService(service);
             
             /* The name is set only once when the accessory is added to Homebridge */
-            dimmerChannel.hapService.updateCharacteristic(this.platform.Characteristic.ConfiguredName, dimmerChannel.label);
+            dimmerChannel.hapService.updateCharacteristic(this.platform.Characteristic.ConfiguredName,
+							  dimmerChannel.label);
             
             this.platform.log.info('Dimmer %s adding channel %s: %s', this.accessory.displayName, dimmerChannel.index, dimmerChannel.index, dimmerChannel.label);
           }

--- a/src/devices/HmIPDimmerMultiChannel.ts
+++ b/src/devices/HmIPDimmerMultiChannel.ts
@@ -78,7 +78,7 @@ export class HmIPDimmerMultiChannel extends HmIPGenericDevice implements Updatea
 
   public updateDevice(hmIPDevice: HmIPDevice, groups: { [key: string]: HmIPGroup }) {
     super.updateDevice(hmIPDevice, groups);
-    const needLabelIndex = (this.accessory.context.device.functionalChannels.size > 2);
+    const needLabelIndex = (this.accessory.context.device.functionalChannels.length > 2);
     for (const id in hmIPDevice.functionalChannels) {
        const channel = hmIPDevice.functionalChannels[id];
        //this.platform.log.info(`Dimmer update: ${JSON.stringify(channel)}`);

--- a/src/devices/HmIPSwitch.ts
+++ b/src/devices/HmIPSwitch.ts
@@ -37,6 +37,7 @@ interface SwitchChannel {
  * HMIPW-DRS8 (Homematic IP Wired Switch Actuator – 8x channels)
  * HMIPW-DRS4 (Homematic IP Wired Switch Actuator – 4x channels)
  * HMIP-DRSI4 (Homematic IP Switch Actuator for DIN rail mount – 4x channels)
+ * ELV-SH-SPS25 (ELV Battery powered switchable power supply)
  *
  */
 export class HmIPSwitch extends HmIPGenericDevice implements Updateable {

--- a/src/devices/HmIPSwitch.ts
+++ b/src/devices/HmIPSwitch.ts
@@ -50,7 +50,7 @@ export class HmIPSwitch extends HmIPGenericDevice implements Updateable {
 
     this.platform.log.debug(`Created switch ${accessory.context.device.label}`);
 
-    const needLabelIndex = (accessory.context.device.functionalChannels.size > 2);
+    const needLabelIndex = (accessory.context.device.functionalChannels.length > 2);
     for (const id in accessory.context.device.functionalChannels) {
       const channel = accessory.context.device.functionalChannels[id];
       if (channel.functionalChannelType === 'SWITCH_CHANNEL' ||

--- a/src/devices/HmIPSwitch.ts
+++ b/src/devices/HmIPSwitch.ts
@@ -50,6 +50,7 @@ export class HmIPSwitch extends HmIPGenericDevice implements Updateable {
 
     this.platform.log.debug(`Created switch ${accessory.context.device.label}`);
 
+    const needLabelIndex = (accessory.context.device.functionalChannels.size > 2);
     for (const id in accessory.context.device.functionalChannels) {
       const channel = accessory.context.device.functionalChannels[id];
       if (channel.functionalChannelType === 'SWITCH_CHANNEL' ||
@@ -57,15 +58,23 @@ export class HmIPSwitch extends HmIPGenericDevice implements Updateable {
         const switchChannel = <SwitchChannel>channel;
 
         if (!this.channels.has(switchChannel.index)) {
+          const label = (switchChannel.label == null || switchChannel.label == '')
+				? (needLabelIndex
+				     ? `${accessory.context.device.label} Channel ${switchChannel.index}`
+				     : accessory.context.device.label)
+				: switchChannel.label;
           switchChannel.hapService = <Service>this.accessory.getServiceById(this.platform.Service.Switch,
 									    switchChannel.index.toString());
           if (!switchChannel.hapService) {
-            const label = (switchChannel.label == null || switchChannel.label == '')
-				? accessory.context.device.label
-				: switchChannel.label;
             const service = new this.platform.Service.Switch(label, switchChannel.index.toString());
+            service.addCharacteristic(this.platform.Characteristic.ConfiguredName);
+	    if (needLabelIndex) {
+              service.updateCharacteristic(this.platform.Characteristic.ServiceLabelIndex,
+                                           switchChannel.index);
+            }
             switchChannel.hapService = this.accessory.addService(service);
           }
+          switchChannel.hapService.updateCharacteristic(this.platform.Characteristic.ConfiguredName, label);
           switchChannel.hapService.getCharacteristic(this.platform.Characteristic.On)
             .on('get', (callback) => {
               this.handleOnGet(switchChannel, callback)
@@ -122,8 +131,8 @@ export class HmIPSwitch extends HmIPGenericDevice implements Updateable {
           if (switchChannel.label !== null && switchChannel.label != '' &&
               switchChannel.label != currentChannel.label) {
             currentChannel.label = switchChannel.label;
-	    currentChannel.hapService.displayName = switchChannel.label;
-            currentChannel.hapService.updateCharacteristic(this.platform.Characteristic.Name, currentChannel.label);
+            currentChannel.hapService.updateCharacteristic(this.platform.Characteristic.ConfiguredName,
+							   currentChannel.label);
             this.platform.log.debug('Switch label of %s channel %d changed to %s', this.accessory.displayName,
 				   currentChannel.index, currentChannel.label);
           }

--- a/src/devices/HmIPSwitchNotificationLight.ts
+++ b/src/devices/HmIPSwitchNotificationLight.ts
@@ -351,6 +351,9 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
   async handleButton1LedHueSet(value: CharacteristicValue, callback: CharacteristicSetCallback) {
     if (this.topLight.hue != value) {
       this.topLight.hue = <number>value;
+      if (this.topLight.hue > 0 || this.topLight.saturation > 0) {
+        this.topLight.lightness = 50;
+      }
       await this.buttonLedColorSet(this.topLight);
     }
     callback(null);
@@ -359,6 +362,9 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
   async handleButton2LedHueSet(value: CharacteristicValue, callback: CharacteristicSetCallback) {
     if (this.bottomLight.hue != value) {
       this.bottomLight.hue = <number>value;
+      if (this.bottomLight.hue > 0 || this.bottomLight.saturation > 0) {
+        this.bottomLight.lightness = 50;
+      }
       await this.buttonLedColorSet(this.bottomLight);
     }
     callback(null);
@@ -385,6 +391,9 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
   async handleButton1LedSaturationSet(value: CharacteristicValue, callback: CharacteristicSetCallback) {
     if (this.topLight.saturation != value) {
       this.topLight.saturation = <number>value;
+      if (this.topLight.hue > 0 || this.topLight.saturation > 0) {
+        this.topLight.lightness = 50;
+      }
       await this.buttonLedColorSet(this.topLight);
     }
     callback(null);
@@ -393,6 +402,9 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
   async handleButton2LedSaturationSet(value: CharacteristicValue, callback: CharacteristicSetCallback) {
     if (this.bottomLight.saturation != value) {
       this.bottomLight.saturation = <number>value;
+      if (this.bottomLight.hue > 0 || this.bottomLight.saturation > 0) {
+        this.bottomLight.lightness = 50;
+      }
       await this.buttonLedColorSet(this.bottomLight);
     }
     callback(null);

--- a/src/devices/HmIPSwitchNotificationLight.ts
+++ b/src/devices/HmIPSwitchNotificationLight.ts
@@ -74,7 +74,7 @@ const HmIPColorPaletteHSL = new Map<string, number[]>([
   ['WHITE', [ 0, 0, 100]], 
 ]);
 
-const HmIPOpticalSignalAllowedValues = [ 'ON', 'OFF', 'BLINKING_MIDDLE', 'FLASH_MIDDLE', 'BILLOW_MIDDLE' ];
+const HmIPOpticalSignalAllowedValues = [ 'OFF', 'ON', 'BLINKING_MIDDLE', 'FLASH_MIDDLE', 'BILLOW_MIDDLE' ];
 
 const HmIPTopLightChannelIndex = 2;
 const HmIPBottomLightChannelIndex = 3;
@@ -185,17 +185,11 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
         .on('get', this.handleButton1LedSaturationGet.bind(this))
         .on('set', this.handleButton1LedSaturationSet.bind(this));
 
-      if (this.topLight.hasOpticalSignal) {
-        if (this.customCharacteristic) {
-          this.button1Led.addOptionalCharacteristic(this.platform.customCharacteristic.characteristic.OpticalSignal);
-          this.button1Led.getCharacteristic(this.platform.customCharacteristic.characteristic.OpticalSignal)
-            .on('get', this.handleButton1LedOpticalSignalGet.bind(this))
-            .on('set', this.handleButton1LedOpticalSignalSet.bind(this));
-        } else {
-          this.button1Led.getCharacteristic(this.platform.Characteristic.RelayState)
-            .on('get', this.handleButton1LedOpticalSignalGet.bind(this))
-            .on('set', this.handleButton1LedOpticalSignalSet.bind(this));
-        }
+      if (this.topLight.hasOpticalSignal && this.customCharacteristic) {
+        this.button1Led.addOptionalCharacteristic(this.platform.customCharacteristic.characteristic.OpticalSignal);
+        this.button1Led.getCharacteristic(this.platform.customCharacteristic.characteristic.OpticalSignal)
+          .on('get', this.handleButton1LedOpticalSignalGet.bind(this))
+          .on('set', this.handleButton1LedOpticalSignalSet.bind(this));
       }
 
       /* Bind handlers for bottom light */
@@ -215,17 +209,11 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
         .on('get', this.handleButton2LedSaturationGet.bind(this))
         .on('set', this.handleButton2LedSaturationSet.bind(this));   
 
-      if (this.bottomLight.hasOpticalSignal) {
-        if (this.customCharacteristic) {
-          this.button2Led.addOptionalCharacteristic(this.platform.customCharacteristic.characteristic.OpticalSignal);
-          this.button2Led.getCharacteristic(this.platform.customCharacteristic.characteristic.OpticalSignal)
-            .on('get', this.handleButton2LedOpticalSignalGet.bind(this))
-            .on('set', this.handleButton2LedOpticalSignalSet.bind(this));
-        } else {
-          this.button2Led.getCharacteristic(this.platform.Characteristic.RelayState)
-            .on('get', this.handleButton2LedOpticalSignalGet.bind(this))
-            .on('set', this.handleButton2LedOpticalSignalSet.bind(this));
-        }
+      if (this.bottomLight.hasOpticalSignal && this.customCharacteristic) {
+        this.button2Led.addOptionalCharacteristic(this.platform.customCharacteristic.characteristic.OpticalSignal);
+        this.button2Led.getCharacteristic(this.platform.customCharacteristic.characteristic.OpticalSignal)
+          .on('get', this.handleButton2LedOpticalSignalGet.bind(this))
+          .on('set', this.handleButton2LedOpticalSignalSet.bind(this));
       }
     
     } else{
@@ -362,19 +350,37 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
   }
 
   async buttonLedColorSet(light: NotificationLight) {
-    const color = this.getNearestHmIPColorFromHSL(light.hue, light.saturation, light.lightness);
+    /*
+     * If it is not possible to use a custom characteristic for the optical signal
+     * function, we encode it's value into the lower digit of the hue value - except
+     * for the OFF value, which has to be set with the "On" characteristic. If the
+     * hue value is a full decimal (10, 20 etc.), the optical signal value doesn't
+     * get changed.
+     */
+    const signal = (this.customCharacteristic ? 0 : (light.hue % 10));
+    const color = this.getNearestHmIPColorFromHSL(light.hue - signal, light.saturation, light.lightness);
+    let setapi = false;
     if (light.simpleColor != color) {
+      setapi = true;
       light.simpleColor = color;
       this.platform.log.debug('Set light color of %s:%s to %s', this.accessory.displayName,
 		light.label, color);
+    }
+    if (signal > 0 && signal < 5) {
+      setapi = true;
+      light.opticalSignal = HmIPOpticalSignalAllowedValues[signal];
+      this.platform.log.debug('Set optical signal of %s:%s to %d', this.accessory.displayName,
+		light.label, signal);
+    }
+    if (setapi) {
       await this.apiSetLight(light.index, light.opticalSignal, light.brightness, color);
     }
   }
 
   async handleButton1LedHueSet(value: CharacteristicValue, callback: CharacteristicSetCallback) {
-    if (this.topLight.hue != value) {
+    if (this.topLight.hue != <number>value) {
       this.topLight.hue = <number>value;
-      if (this.topLight.hue > 0 || this.topLight.saturation > 0) {
+      if (this.topLight.hue >= 10 || this.topLight.saturation > 0) {
         this.topLight.lightness = 50;
       }
       await this.buttonLedColorSet(this.topLight);
@@ -383,9 +389,9 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
   }
 
   async handleButton2LedHueSet(value: CharacteristicValue, callback: CharacteristicSetCallback) {
-    if (this.bottomLight.hue != value) {
+    if (this.bottomLight.hue != <number>value) {
       this.bottomLight.hue = <number>value;
-      if (this.bottomLight.hue > 0 || this.bottomLight.saturation > 0) {
+      if (this.bottomLight.hue >= 10 || this.bottomLight.saturation > 0) {
         this.bottomLight.lightness = 50;
       }
       await this.buttonLedColorSet(this.bottomLight);
@@ -412,9 +418,9 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
   }
 
   async handleButton1LedSaturationSet(value: CharacteristicValue, callback: CharacteristicSetCallback) {
-    if (this.topLight.saturation != value) {
+    if (this.topLight.saturation != <number>value) {
       this.topLight.saturation = <number>value;
-      if (this.topLight.hue > 0 || this.topLight.saturation > 0) {
+      if (this.topLight.hue >= 10 || this.topLight.saturation > 0) {
         this.topLight.lightness = 50;
       }
       await this.buttonLedColorSet(this.topLight);
@@ -423,9 +429,9 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
   }
 
   async handleButton2LedSaturationSet(value: CharacteristicValue, callback: CharacteristicSetCallback) {
-    if (this.bottomLight.saturation != value) {
+    if (this.bottomLight.saturation != <number>value) {
       this.bottomLight.saturation = <number>value;
-      if (this.bottomLight.hue > 0 || this.bottomLight.saturation > 0) {
+      if (this.bottomLight.hue >= 10 || this.bottomLight.saturation > 0) {
         this.bottomLight.lightness = 50;
       }
       await this.buttonLedColorSet(this.bottomLight);
@@ -440,9 +446,7 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
   buttonLedOpticalSignalGet(light: NotificationLight) {
     this.platform.log.debug('Get optical signal of %s:%s (%s)', this.accessory.displayName, light.label,
       light.opticalSignal);
-    return this.customCharacteristic
-		? <string>light.opticalSignal
-		: HmIPOpticalSignalAllowedValues.indexOf(<string>light.opticalSignal);
+    return <string>light.opticalSignal;
   }
 
   handleButton1LedOpticalSignalGet(callback: CharacteristicGetCallback) {
@@ -454,8 +458,8 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
   }
 
   async buttonLedOpticalSignalSet(light: NotificationLight, value: string, callback: CharacteristicSetCallback) {
-    if (HmIPOpticalSignalAllowedValues.includes(value.toUpperCase())) {
-      value = value.toUpperCase();
+    value = value.toUpperCase();
+    if (HmIPOpticalSignalAllowedValues.includes(value)) {
       if (light.opticalSignal != value) {
         light.opticalSignal = value;
         this.platform.log.debug('Set optical signal of %s:%s to %s', this.accessory.displayName,
@@ -470,16 +474,10 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
   }
 
   async handleButton1LedOpticalSignalSet(value: CharacteristicValue, callback: CharacteristicSetCallback) {
-    if (typeof value === "number") {
-      value = HmIPOpticalSignalAllowedValues[value];
-    }
     await this.buttonLedOpticalSignalSet(this.topLight, <string>value, callback);
   }
 
   async handleButton2LedOpticalSignalSet(value: CharacteristicValue, callback: CharacteristicSetCallback) {
-    if (typeof value === "number") {
-      value = (value < 0 || value > 4 ? "OFF" : HmIPOpticalSignalAllowedValues[value]);
-    }
     await this.buttonLedOpticalSignalSet(this.bottomLight, <string>value, callback);
   }
 
@@ -570,8 +568,10 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
       if (light.hasOpticalSignal) {
         if (channel.opticalSignalBehaviour !== null && channel.opticalSignalBehaviour !== light.opticalSignal) {
           light.opticalSignal = channel.opticalSignalBehaviour;
-          light.service.updateCharacteristic(this.platform.customCharacteristic.characteristic.OpticalSignal,
-					     light.opticalSignal);
+          if (this.customCharacteristic) {
+              light.service.updateCharacteristic(this.platform.customCharacteristic.characteristic.OpticalSignal,
+			     light.opticalSignal);
+          }
 	  if (light.opticalSignal == 'OFF') {
             onstate = false;
           } else if (onstate === null) {

--- a/src/devices/HmIPSwitchNotificationLight.ts
+++ b/src/devices/HmIPSwitchNotificationLight.ts
@@ -97,6 +97,7 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
   private bottomLight! : NotificationLight;
 
   private simpleSwitch : boolean = false;
+  private customCharacteristic : boolean = true;
 
   constructor(
     platform: HmIPPlatform,
@@ -106,7 +107,8 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
 
     /* Create switch service */
     this.platform.log.debug(`Created switch ${accessory.context.device.label}`);
-    this.service = this.accessory.getService(this.platform.Service.Switch) || this.accessory.addService(this.platform.Service.Switch);
+    this.service = this.accessory.getService(this.platform.Service.Switch) ||
+			this.accessory.addService(this.platform.Service.Switch);
     this.service.setCharacteristic(this.platform.Characteristic.Name, accessory.context.device.label);
 
     this.service.getCharacteristic(this.platform.Characteristic.On)
@@ -114,6 +116,7 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
       .on('set', this.handleOnSet.bind(this));
 
     this.simpleSwitch = this.accessoryConfig?.['simpleSwitch'] === true;
+    this.customCharacteristic = this.accessoryConfig?.['customCharacteristic'] === true;
 
     if (!this.simpleSwitch){
 
@@ -122,13 +125,17 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
       this.button1Led = <Service>this.accessory.getServiceById(this.platform.Service.Lightbulb, 'Button1');
       if (channel.functionalChannelType === 'NOTIFICATION_LIGHT_CHANNEL') {
         if (!this.button1Led) {
-          this.button1Led = new this.platform.Service.Lightbulb(channel.label, 'Button1');
-          if (this.button1Led) {
-            this.button1Led = this.accessory.addService(this.button1Led);
+          const service = new this.platform.Service.Lightbulb(channel.label, 'Button1');
+          if (service) {
+            service.addCharacteristic(this.platform.Characteristic.ServiceLabelIndex);
+            service.addCharacteristic(this.platform.Characteristic.ConfiguredName);
+            this.button1Led = this.accessory.addService(service);
           } else {
             this.platform.log.error('Error adding service to %s for button 1 led', accessory.context.device.label);
           }
         }
+        this.button1Led.updateCharacteristic(this.platform.Characteristic.ServiceLabelIndex, 1);
+	this.button1Led.updateCharacteristic(this.platform.Characteristic.ConfiguredName, channel.label);
         this.topLight = new NotificationLight('Button 1', <NotificationLightChannel>channel, this.button1Led);
         if (this.topLight.hasOpticalSignal) {
           this.platform.log.debug(`Detected opticalSignal feature for ${channel.label}`);
@@ -142,13 +149,17 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
       this.button2Led = <Service>this.accessory.getServiceById(this.platform.Service.Lightbulb, 'Button2');
       if (channel.functionalChannelType === 'NOTIFICATION_LIGHT_CHANNEL') {
         if (!this.button2Led) {
-          this.button2Led = new this.platform.Service.Lightbulb(channel.label, 'Button2');
-          if (this.button2Led) {
-            this.button2Led = this.accessory.addService(this.button2Led);
+          const service = new this.platform.Service.Lightbulb(channel.label, 'Button2');
+          if (service) {
+            service.addCharacteristic(this.platform.Characteristic.ServiceLabelIndex);
+            service.addCharacteristic(this.platform.Characteristic.ConfiguredName);
+            this.button2Led = this.accessory.addService(service);
           } else {
             this.platform.log.error('Error adding service to %s for button 2 led', accessory.context.device.label);
           }
         } 
+        this.button2Led.updateCharacteristic(this.platform.Characteristic.ServiceLabelIndex, 2);
+	this.button2Led.updateCharacteristic(this.platform.Characteristic.ConfiguredName, channel.label);
         this.bottomLight = new NotificationLight('Button 2', <NotificationLightChannel>channel, this.button2Led);
         if (this.bottomLight.hasOpticalSignal) {
           this.platform.log.debug(`Detected opticalSignal feature for ${channel.label}`);
@@ -175,10 +186,16 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
         .on('set', this.handleButton1LedSaturationSet.bind(this));
 
       if (this.topLight.hasOpticalSignal) {
-        this.button1Led.addOptionalCharacteristic(this.platform.customCharacteristic.characteristic.OpticalSignal);
-        this.button1Led.getCharacteristic(this.platform.customCharacteristic.characteristic.OpticalSignal)
-          .on('get', this.handleButton1LedOpticalSignalGet.bind(this))
-          .on('set', this.handleButton1LedOpticalSignalSet.bind(this));
+        if (this.customCharacteristic) {
+          this.button1Led.addOptionalCharacteristic(this.platform.customCharacteristic.characteristic.OpticalSignal);
+          this.button1Led.getCharacteristic(this.platform.customCharacteristic.characteristic.OpticalSignal)
+            .on('get', this.handleButton1LedOpticalSignalGet.bind(this))
+            .on('set', this.handleButton1LedOpticalSignalSet.bind(this));
+        } else {
+          this.button1Led.getCharacteristic(this.platform.Characteristic.RelayState)
+            .on('get', this.handleButton1LedOpticalSignalGet.bind(this))
+            .on('set', this.handleButton1LedOpticalSignalSet.bind(this));
+        }
       }
 
       /* Bind handlers for bottom light */
@@ -199,10 +216,16 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
         .on('set', this.handleButton2LedSaturationSet.bind(this));   
 
       if (this.bottomLight.hasOpticalSignal) {
-        this.button2Led.addOptionalCharacteristic(this.platform.customCharacteristic.characteristic.OpticalSignal);
-        this.button2Led.getCharacteristic(this.platform.customCharacteristic.characteristic.OpticalSignal)
-          .on('get', this.handleButton2LedOpticalSignalGet.bind(this))
-          .on('set', this.handleButton2LedOpticalSignalSet.bind(this));
+        if (this.customCharacteristic) {
+          this.button2Led.addOptionalCharacteristic(this.platform.customCharacteristic.characteristic.OpticalSignal);
+          this.button2Led.getCharacteristic(this.platform.customCharacteristic.characteristic.OpticalSignal)
+            .on('get', this.handleButton2LedOpticalSignalGet.bind(this))
+            .on('set', this.handleButton2LedOpticalSignalSet.bind(this));
+        } else {
+          this.button2Led.getCharacteristic(this.platform.Characteristic.RelayState)
+            .on('get', this.handleButton2LedOpticalSignalGet.bind(this))
+            .on('set', this.handleButton2LedOpticalSignalSet.bind(this));
+        }
       }
     
     } else{
@@ -414,10 +437,12 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
   /*
    * Light OpticalSignal characteristic handlers
    */
-  buttonLedOpticalSignalGet(light: NotificationLight): string {
+  buttonLedOpticalSignalGet(light: NotificationLight) {
     this.platform.log.debug('Get optical signal of %s:%s (%s)', this.accessory.displayName, light.label,
       light.opticalSignal);
-    return <string>light.opticalSignal;
+    return this.customCharacteristic
+		? <string>light.opticalSignal
+		: HmIPOpticalSignalAllowedValues.indexOf(<string>light.opticalSignal);
   }
 
   handleButton1LedOpticalSignalGet(callback: CharacteristicGetCallback) {
@@ -445,10 +470,16 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
   }
 
   async handleButton1LedOpticalSignalSet(value: CharacteristicValue, callback: CharacteristicSetCallback) {
+    if (typeof value === "number") {
+      value = HmIPOpticalSignalAllowedValues[value];
+    }
     await this.buttonLedOpticalSignalSet(this.topLight, <string>value, callback);
   }
 
   async handleButton2LedOpticalSignalSet(value: CharacteristicValue, callback: CharacteristicSetCallback) {
+    if (typeof value === "number") {
+      value = (value < 0 || value > 4 ? "OFF" : HmIPOpticalSignalAllowedValues[value]);
+    }
     await this.buttonLedOpticalSignalSet(this.bottomLight, <string>value, callback);
   }
 
@@ -496,8 +527,7 @@ export class HmIPSwitchNotificationLight extends HmIPGenericDevice implements Up
       
       if (channel.label !== null && channel.label !== '' && light.label !== channel.label) {
         light.label = channel.label;
-        light.service.displayName = light.label;
-        light.service.updateCharacteristic(this.platform.Characteristic.Name, light.label);
+        light.service.updateCharacteristic(this.platform.Characteristic.ConfiguredName, light.label);
         this.platform.log.debug('Update light label of %s to %s', this.accessory.displayName, light.label);
       }
 


### PR DESCRIPTION
Hi,
just added support for the HmIP WindowState characteristic of the security zones. The optional homekit characteristic isn't usable with the iOS home app, but shows up on node-red and allows to control the security system depending on the state of the window and door sensors.