### PR TITLE
Add HmIPW-DRS8 multi-channel switch cleanup and GitHub install support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## 1.4.0 (2026-05-17)
+
+### Improvements
+
+- **HmIPW-DRS8 / HmIPW-DRS4 / HmIP-BS2 / HmIP-PCBS2 / HmIP-MOD-OC8 / HmIP-WHS2 / HmIP-DRSI4**:
+  All switch channels are now exposed as individual HomeKit Switch services (multi-channel
+  support, originally added in master via @gkminix's work, is now part of a tagged release).
+- **Switches**: Add `ConfiguredName` characteristic per channel so channel-specific labels
+  are displayed in the Home app, and provide a sensible default name when the device label
+  is empty.
+- **Switches**: Migrate cached accessories from older single-service layout by removing the
+  orphaned legacy Switch service that was created without a subtype.
+- **MULTI_MODE_INPUT_SWITCH_CHANNEL**: State updates from this channel type are now applied
+  (previously only handled at registration time).
+
+### Packaging
+
+- Add `prepare` script and `files` allowlist so the plugin can be installed straight from
+  a GitHub fork (`npm i github:<user>/homebridge-homematicip`) and still ship a built
+  `dist/` directory.
+
 ## 1.3.1 (2024-01-13)
 
 ### New devices

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-homematicip",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-homematicip",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "bottleneck": "^2.19.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-homematicip",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Homematic IP plugin for homebridge",
   "license": "Apache-2.0",
   "author": "Marc Sowen <marc@sowen.net>",
@@ -20,10 +20,17 @@
   },
   "main": "dist/index.js",
   "type": "module",
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "scripts": {
     "lint": "eslint src/**.ts",
     "watch": "pnpm run build && pnpm link && nodemon",
     "build": "rimraf ./dist && tsc",
+    "prepare": "npm run build",
     "prepublishOnly": "pnpm run lint && pnpm run build"
   },
   "engines": {

--- a/src/devices/HmIPSwitch.ts
+++ b/src/devices/HmIPSwitch.ts
@@ -50,6 +50,15 @@ export class HmIPSwitch extends HmIPGenericDevice implements Updateable {
 
     this.platform.log.debug(`Created switch ${accessory.context.device.label}`);
 
+    // Remove a legacy Switch service that older plugin versions added without a subtype.
+    // Without this cleanup, upgraded accessories keep an orphaned single Switch alongside
+    // the new per-channel services (e.g. on HmIPW-DRS8 cached from v1.3.1).
+    const legacyService = this.accessory.getService(this.platform.Service.Switch);
+    if (legacyService && !legacyService.subtype) {
+      this.platform.log.info('Removing legacy single-channel switch service from %s', this.accessory.displayName);
+      this.accessory.removeService(legacyService);
+    }
+
     for (const id in accessory.context.device.functionalChannels) {
       const channel = accessory.context.device.functionalChannels[id];
       if (channel.functionalChannelType === 'SWITCH_CHANNEL' ||
@@ -61,10 +70,12 @@ export class HmIPSwitch extends HmIPGenericDevice implements Updateable {
 									    switchChannel.index.toString());
           if (!switchChannel.hapService) {
             const label = (switchChannel.label == null || switchChannel.label == '')
-				? accessory.context.device.label
+				? `${accessory.context.device.label} ${switchChannel.index}`
 				: switchChannel.label;
             const service = new this.platform.Service.Switch(label, switchChannel.index.toString());
+            service.addOptionalCharacteristic(this.platform.Characteristic.ConfiguredName);
             switchChannel.hapService = this.accessory.addService(service);
+            switchChannel.hapService.updateCharacteristic(this.platform.Characteristic.ConfiguredName, label);
           }
           switchChannel.hapService.getCharacteristic(this.platform.Characteristic.On)
             .on('get', (callback) => {
@@ -112,7 +123,8 @@ export class HmIPSwitch extends HmIPGenericDevice implements Updateable {
     super.updateDevice(hmIPDevice, groups);
     for (const id in hmIPDevice.functionalChannels) {
       const channel = hmIPDevice.functionalChannels[id];
-      if (channel.functionalChannelType === 'SWITCH_CHANNEL') {
+      if (channel.functionalChannelType === 'SWITCH_CHANNEL' ||
+          channel.functionalChannelType === 'MULTI_MODE_INPUT_SWITCH_CHANNEL') {
         const switchChannel = <SwitchChannel>channel;
         const currentChannel = this.channels.get(switchChannel.index);
         //this.platform.log.debug(`Switch update: ${JSON.stringify(channel)}`);
@@ -124,6 +136,7 @@ export class HmIPSwitch extends HmIPGenericDevice implements Updateable {
             currentChannel.label = switchChannel.label;
 	    currentChannel.hapService.displayName = switchChannel.label;
             currentChannel.hapService.updateCharacteristic(this.platform.Characteristic.Name, currentChannel.label);
+            currentChannel.hapService.updateCharacteristic(this.platform.Characteristic.ConfiguredName, currentChannel.label);
             this.platform.log.debug('Switch label of %s channel %d changed to %s', this.accessory.displayName,
 				   currentChannel.index, currentChannel.label);
           }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -11,4 +11,4 @@ export const PLUGIN_NAME = 'homebridge-homematicip';
 /**
  * Version to be used in protocol communication
  */
-export const PLUGIN_VERSION = '1.3.1';
+export const PLUGIN_VERSION = '1.4.0';


### PR DESCRIPTION
This PR improves multi-channel switch handling for Homematic IP switch devices such as HmIPW-DRS8.

Summary:
- Sets ConfiguredName per switch channel to avoid duplicate unnamed HomeKit services.
- Adds a fallback channel label in the format `<device label> <channel index>` when the HmIP cloud payload does not provide a channel label.
- Removes the legacy single-channel Switch service without subtype that can remain in cached Homebridge accessories after upgrading from the old npm release.
- Handles `MULTI_MODE_INPUT_SWITCH_CHANNEL` consistently in the update path.
- Prepares installation from GitHub by adding a `prepare` build script and package `files` allowlist.
- Bumps package metadata to 1.4.0 and documents the change in CHANGELOG.md.

Context:
The published npm version 1.3.1 only exposes the first channel of HmIPW-DRS8. The current master branch already contains the basic multi-channel mapping, but users installing from npm do not receive it. This patch keeps the existing multi-channel implementation, improves HomeKit naming/migration behavior, and makes fork-based installation possible while waiting for a release.

Validation:
- `npm install --ignore-scripts`: OK
- `npm run build`: OK
- `npx eslint 'src/**/*.ts'`: existing lint errors remain in unchanged files from master; no new lint errors were introduced by this patch.

Notes:
- No speculative support was added for HmIPW-DRI32, HmIP-HAP2, or HmIPW-DRAP because sample API payloads are required to implement these safely.
- Users upgrading from 1.3.1 may need to reassign HomeKit scenes/automations that used channel 1 because the old untyped service is replaced by typed channel services.
